### PR TITLE
Prepare shelly plus 1pm support and add some default items

### DIFF
--- a/dbus_shelly.py
+++ b/dbus_shelly.py
@@ -49,7 +49,7 @@ class Server(object):
 
 		# Tell the meter to send a full status
 		await socket.send(json.dumps({
-			"id": "GetDeviceInfo-{}".format(next(tx_count)),
+			"id": f"GetDeviceInfo-{next(tx_count)}",
 			"method":"Shelly.GetDeviceInfo"
 		}))
 


### PR DESCRIPTION
- Some cleaning with f-string
- Prepare Shelly 1pm support, opened a Shelly ticket to ask to send voltage, current and power on NotifyStatus (only energy is send for now (v1.0.3)
- Update to display the meter name base on the type of shelly device and display the device name as custom name
- Add Hardware version and Serial item
- Change the firmware field to the shorter one since it's the name used in shelly change log