### PR TITLE
discovery: handle empty ip_addresses

### DIFF
--- a/discovery.py
+++ b/discovery.py
@@ -67,7 +67,8 @@ class ShellyDiscovery(object):
 			self.aiozc.zeroconf, ["_shelly._tcp.local."], handlers=[self.on_service_state_change]
 		)
 
-		self._start_add_by_ip_address_task(ip_addresses)
+		if ip_addresses:
+			self._start_add_by_ip_address_task(ip_addresses)
 
 		await self.bus.wait_for_disconnect()
 


### PR DESCRIPTION
If there are no saved/configured IP addresses, `_start_add_by_ip_address_task` feeds the empty string to the split() function, which in turn creates a broken Device object with an empty/invalid 0.0.0.0 IP address. Skip creating objects by IP address if the setting is empty.